### PR TITLE
Ch5 subdomain guesser: Start gather goroutine before looping over Scanner.

### DIFF
--- a/ch-5/subdomain_guesser/main.go
+++ b/ch-5/subdomain_guesser/main.go
@@ -119,11 +119,6 @@ func main() {
 		go worker(tracker, fqdns, gather, *flServerAddr)
 	}
 
-	for scanner.Scan() {
-		fqdns <- fmt.Sprintf("%s.%s", scanner.Text(), *flDomain)
-	}
-	// Note: We could check scanner.Err() here.
-
 	go func() {
 		for r := range gather {
 			results = append(results, r...)
@@ -131,6 +126,11 @@ func main() {
 		var e empty
 		tracker <- e
 	}()
+
+	for scanner.Scan() {
+		fqdns <- fmt.Sprintf("%s.%s", scanner.Text(), *flDomain)
+	}
+	// Note: We could check scanner.Err() here.
 
 	close(fqdns)
 	for i := 0; i < *flWorkerCount; i++ {


### PR DESCRIPTION
Otherwise gather is blocked when the workers try to write to it after
processing their first elements since nothing is reading from it, yet.

Thanks to Sean Liao on the Gophers Slack for pointing this out.
This resolves #11.