### PR TITLE
Update main.go

### DIFF
--- a/ch-3/bing-metadata/client/main.go
+++ b/ch-3/bing-metadata/client/main.go
@@ -62,12 +62,18 @@ func main() {
 		domain,
 		filetype,
 		filetype)
+	
 	search := fmt.Sprintf("http://www.bing.com/search?q=%s", url.QueryEscape(q))
-	doc, err := goquery.NewDocument(search)
+	res, err := http.Get(search)
+	if err != nil {
+		return
+	}
+	
+	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
 		log.Panicln(err)
 	}
-
-	s := "html body div#b_content ol#b_results li.b_algo div.b_title h2"
+	defer res.Body.Close()
+	s := "html body div#b_content ol#b_results li.b_algo h2"
 	doc.Find(s).Each(handler)
 }


### PR DESCRIPTION
1. goquery.NewDocument() is depcreated. Use goquery.NewDocumentFromReader() with body of normal http get request instead (as stated in goquery documentation)

2. goquery search string changed for href document location