### PR TITLE
Added newline

### DIFF
--- a/ch-14/grpcapi/implant.proto
+++ b/ch-14/grpcapi/implant.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package grpcapi;
+option go_package = "./";
 
 // Implant defines our C2 API functions
 service Implant {


### PR DESCRIPTION
option go_package = "./"; - Added as it is now required in the newer versions of protoc

https://developers.google.com/protocol-buffers/docs/reference/go-generated#package